### PR TITLE
fix: wrong json property name for difficulty rating

### DIFF
--- a/OsuSharp/Models/Beatmaps/DifficultyAttributes.cs
+++ b/OsuSharp/Models/Beatmaps/DifficultyAttributes.cs
@@ -20,7 +20,7 @@ public class DifficultyAttributes
   /// The difficulty rating of the beatmap.
   /// </summary>
   [JsonProperty("star_rating")]
-  public float StarRating { get; private set; }
+  public float DifficultyRating { get; private set; }
 
   /// <summary>
   /// The aim difficulty rating of the beatmap. This property may be null as it is exclusive to osu!standard beatmaps.

--- a/OsuSharp/Models/Beatmaps/DifficultyAttributes.cs
+++ b/OsuSharp/Models/Beatmaps/DifficultyAttributes.cs
@@ -19,8 +19,8 @@ public class DifficultyAttributes
   /// <summary>
   /// The difficulty rating of the beatmap.
   /// </summary>
-  [JsonProperty("difficulty_rating")]
-  public float DifficultyRating { get; private set; }
+  [JsonProperty("star_rating")]
+  public float StarRating { get; private set; }
 
   /// <summary>
   /// The aim difficulty rating of the beatmap. This property may be null as it is exclusive to osu!standard beatmaps.


### PR DESCRIPTION
Fixes some minor stuff I caught while trying out the library today.

*  [Rename DifficultyRating to StarRating](https://github.com/minisbett/osu-sharp/commit/f0174e63d56bdd691f427e06e6fc21b33f9d8cd7) as per the [osu! documentation](https://osu.ppy.sh/docs/index.html#beatmapdifficultyattributes:~:text=of%20length%20100.-,BeatmapDifficultyAttributes,-Represent%20beatmap%20difficulty)
* ~~[Add description attributes to RankedStatus enum](https://github.com/minisbett/osu-sharp/commit/6455fda6590bc45757f2a34a596c0a3e1609dfcc) since otherwise the `GetBeatmapAsync` request would cause an exception~~

I was going to add the ability to pass mods onto the `GetDifficultyAttributesAsync` endpoint, but it seems like the API expects the data in the body of the request as JSON, and I wasn't sure how you would like to deal with cases like these, [my changes](https://github.com/matte-ek/osu-sharp/commit/f4ecaa63e15afe35922651b1a05013d8d35979bb) FWIW.

Nice work on the library so far though, nice and easy to work with, and code is very nice.