### PR TITLE
Add mods and ruleset parameters to GetDifficultyAttributesAsync

### DIFF
--- a/OsuSharp/Converters/StringEnumConverter.cs
+++ b/OsuSharp/Converters/StringEnumConverter.cs
@@ -60,7 +60,9 @@ internal class StringEnumConverter : JsonConverter
       // Write the description attribute value to the writer.
       writer.WriteValue(descriptionAttribute.Description);
     }
-
-    throw new JsonSerializationException($"{value?.GetType()} is not an enum value or array.");
+    else
+    {
+      throw new JsonSerializationException($"{value?.GetType()} is not an enum value or array.");
+    }
   }
 }

--- a/OsuSharp/Converters/StringEnumConverter.cs
+++ b/OsuSharp/Converters/StringEnumConverter.cs
@@ -61,8 +61,6 @@ internal class StringEnumConverter : JsonConverter
       writer.WriteValue(descriptionAttribute.Description);
     }
     else
-    {
       throw new JsonSerializationException($"{value?.GetType()} is not an enum value or array.");
-    }
   }
 }

--- a/OsuSharp/Endpoints/Beatmaps.cs
+++ b/OsuSharp/Endpoints/Beatmaps.cs
@@ -157,7 +157,7 @@ public partial class OsuApiClient
   /// <param name="id">The ID of the beatmap.</param>
   /// <param name="ruleset">The ruleset to get the attributes from.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, Ruleset? ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, null, ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, 0, ruleset);
 
   /// <summary>
   /// Gets the difficulty attributes of the beatmap with the specified ID, optionally in the specified ruleset and the specified mods.
@@ -170,7 +170,20 @@ public partial class OsuApiClient
   /// <param name="mods">Optional. The mods to consider for the attributes, as an array of the acronyms.</param>
   /// <param name="ruleset">Optional. The ruleset to get the attributes from. Defaults to osu!standard.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string[] mods, Ruleset? ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string[] mods, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+
+  /// <summary>
+  /// Gets the difficulty attributes of the beatmap with the specified ID, optionally in the specified ruleset and the specified mods.
+  /// If the beatmap was not found, null is returned.
+  /// <br/><br/>
+  /// API notes:<br/>
+  /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
+  /// </summary>
+  /// <param name="id">The ID of the beatmap.</param>
+  /// <param name="mods">Optional. The mods to consider for the attributes, as a string with the acronyms, such as "HDHR".</param>
+  /// <param name="ruleset">Optional. The ruleset to get the attributes from. Defaults to osu!standard.</param>
+  /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string mods, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods.Chunk(2).Select(chunk => new string(chunk)).ToArray(), ruleset);
 
   /// <summary>
   /// Gets the difficulty attributes of the beatmap with the specified ID, optionally in the specified ruleset and the specified mods.
@@ -183,7 +196,7 @@ public partial class OsuApiClient
   /// <param name="mods">Optional. The mods to consider for the attributes, as the bitset number.</param>
   /// <param name="ruleset">Optional. The ruleset to get the attributes from. Defaults to osu!standard.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, int mods, Ruleset? ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, int mods, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
 
   /// <summary>
   /// Gets the difficulty attributes of the beatmap with the specified ID, in the specified ruleset and with the specified mods.

--- a/OsuSharp/Endpoints/Beatmaps.cs
+++ b/OsuSharp/Endpoints/Beatmaps.cs
@@ -155,10 +155,16 @@ public partial class OsuApiClient
   /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
   /// </summary>
   /// <param name="id">The ID of the beatmap.</param>
+  /// <param name="mods">The mods to get the attributes from.</param>
+  /// <param name="ruleset">The ruleset to get the attributes from.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public async Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id)
+  public async Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string? mods = null, string? ruleset = null)
   {
     // Send the request and return the difficulty attributes object.
-    return await GetFromJsonAsync<DifficultyAttributes>($"beatmaps/{id}/attributes", jsonSelector: x => x["attributes"], method: HttpMethod.Post);
+    return await GetFromJsonAsync<DifficultyAttributes>($"beatmaps/{id}/attributes", new Dictionary<string, object?>()
+    {
+      { "mods", mods },
+      { "ruleset", ruleset }
+    }, x => x["attributes"], method: HttpMethod.Post);
   }
 }

--- a/OsuSharp/Endpoints/Beatmaps.cs
+++ b/OsuSharp/Endpoints/Beatmaps.cs
@@ -157,46 +157,46 @@ public partial class OsuApiClient
   /// <param name="id">The ID of the beatmap.</param>
   /// <param name="ruleset">The ruleset to get the attributes from.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string? ruleset = null) => GetDifficultyAttributesInternalAsync(id, null, ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, Ruleset? ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, null, ruleset);
 
   /// <summary>
-  /// Gets the beatmap with the specified ID.
+  /// Gets the difficulty attributes of the beatmap with the specified ID, optionally in the specified ruleset and the specified mods.
   /// If the beatmap was not found, null is returned.
   /// <br/><br/>
   /// API notes:<br/>
   /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
   /// </summary>
   /// <param name="id">The ID of the beatmap.</param>
-  /// <param name="mods">The mods in the acronym form to get the attributes from.</param>
-  /// <param name="ruleset">The ruleset to get the attributes from.</param>
+  /// <param name="mods">Optional. The mods to consider for the attributes, as an array of the acronyms.</param>
+  /// <param name="ruleset">Optional. The ruleset to get the attributes from. Defaults to osu!standard.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string[] mods, string? ruleset = null) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string[] mods, Ruleset? ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
 
   /// <summary>
-  /// Gets the beatmap with the specified ID.
+  /// Gets the difficulty attributes of the beatmap with the specified ID, optionally in the specified ruleset and the specified mods.
   /// If the beatmap was not found, null is returned.
   /// <br/><br/>
   /// API notes:<br/>
   /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
   /// </summary>
   /// <param name="id">The ID of the beatmap.</param>
-  /// <param name="mods">The mods in a bitset form to get the attributes from.</param>
-  /// <param name="ruleset">The ruleset to get the attributes from.</param>
+  /// <param name="mods">Optional. The mods to consider for the attributes, as the bitset number.</param>
+  /// <param name="ruleset">Optional. The ruleset to get the attributes from. Defaults to osu!standard.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, int mods, string? ruleset = null) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, int mods, Ruleset? ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
 
   /// <summary>
-  /// Gets the beatmap with the specified ID.
+  /// Gets the difficulty attributes of the beatmap with the specified ID, in the specified ruleset and with the specified mods.
   /// If the beatmap was not found, null is returned.
   /// <br/><br/>
   /// API notes:<br/>
   /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
   /// </summary>
   /// <param name="id">The ID of the beatmap.</param>
-  /// <param name="mods">The mods in either a bitset of mods or a string array with the mods.</param>
+  /// <param name="mods">The mods to consider for the attributes, in the raw format passed to the API.</param>
   /// <param name="ruleset">The ruleset to get the attributes from.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  private async Task<DifficultyAttributes?> GetDifficultyAttributesInternalAsync(int id, object? mods = null, string? ruleset = null)
+  private async Task<DifficultyAttributes?> GetDifficultyAttributesInternalAsync(int id, object mods, Ruleset ruleset)
   {
     // Send the request and return the difficulty attributes object.
     return await GetFromJsonAsync<DifficultyAttributes>($"beatmaps/{id}/attributes", new Dictionary<string, object?>()

--- a/OsuSharp/Endpoints/Beatmaps.cs
+++ b/OsuSharp/Endpoints/Beatmaps.cs
@@ -155,16 +155,54 @@ public partial class OsuApiClient
   /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
   /// </summary>
   /// <param name="id">The ID of the beatmap.</param>
-  /// <param name="mods">The mods to get the attributes from.</param>
   /// <param name="ruleset">The ruleset to get the attributes from.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public async Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string? mods = null, string? ruleset = null)
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string? ruleset = null) => GetDifficultyAttributesInternalAsync(id, null, ruleset);
+
+  /// <summary>
+  /// Gets the beatmap with the specified ID.
+  /// If the beatmap was not found, null is returned.
+  /// <br/><br/>
+  /// API notes:<br/>
+  /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
+  /// </summary>
+  /// <param name="id">The ID of the beatmap.</param>
+  /// <param name="mods">The mods in the acronym form to get the attributes from.</param>
+  /// <param name="ruleset">The ruleset to get the attributes from.</param>
+  /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string[] mods, string? ruleset = null) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+
+  /// <summary>
+  /// Gets the beatmap with the specified ID.
+  /// If the beatmap was not found, null is returned.
+  /// <br/><br/>
+  /// API notes:<br/>
+  /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
+  /// </summary>
+  /// <param name="id">The ID of the beatmap.</param>
+  /// <param name="mods">The mods in a bitset form to get the attributes from.</param>
+  /// <param name="ruleset">The ruleset to get the attributes from.</param>
+  /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, int mods, string? ruleset = null) => GetDifficultyAttributesInternalAsync(id, mods, ruleset);
+
+  /// <summary>
+  /// Gets the beatmap with the specified ID.
+  /// If the beatmap was not found, null is returned.
+  /// <br/><br/>
+  /// API notes:<br/>
+  /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
+  /// </summary>
+  /// <param name="id">The ID of the beatmap.</param>
+  /// <param name="mods">The mods in either a bitset of mods or a string array with the mods.</param>
+  /// <param name="ruleset">The ruleset to get the attributes from.</param>
+  /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
+  private async Task<DifficultyAttributes?> GetDifficultyAttributesInternalAsync(int id, object? mods = null, string? ruleset = null)
   {
     // Send the request and return the difficulty attributes object.
     return await GetFromJsonAsync<DifficultyAttributes>($"beatmaps/{id}/attributes", new Dictionary<string, object?>()
     {
-      { "mods", mods },
-      { "ruleset", ruleset }
+      { "ruleset", ruleset },
+      { "mods", mods }
     }, x => x["attributes"], method: HttpMethod.Post);
   }
 }

--- a/OsuSharp/Endpoints/Beatmaps.cs
+++ b/OsuSharp/Endpoints/Beatmaps.cs
@@ -155,7 +155,7 @@ public partial class OsuApiClient
   /// <a href="https://osu.ppy.sh/docs/index.html#get-beatmap"/>
   /// </summary>
   /// <param name="id">The ID of the beatmap.</param>
-  /// <param name="ruleset">The ruleset to get the attributes from.</param>
+  /// <param name="ruleset">Optional. The ruleset to get the attributes from. Default to osu!standard.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
   public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, 0, ruleset);
 
@@ -183,7 +183,7 @@ public partial class OsuApiClient
   /// <param name="mods">Optional. The mods to consider for the attributes, as a string with the acronyms, such as "HDHR".</param>
   /// <param name="ruleset">Optional. The ruleset to get the attributes from. Defaults to osu!standard.</param>
   /// <returns>The difficulty attributes or null, if the beatmap was not found.</returns>
-  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string mods, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods.Chunk(2).Select(chunk => new string(chunk)).ToArray(), ruleset);
+  public Task<DifficultyAttributes?> GetDifficultyAttributesAsync(int id, string mods, Ruleset ruleset = Ruleset.Osu) => GetDifficultyAttributesInternalAsync(id, mods.Chunk(2).Select(x => new string(x)).ToArray(), ruleset);
 
   /// <summary>
   /// Gets the difficulty attributes of the beatmap with the specified ID, optionally in the specified ruleset and the specified mods.

--- a/OsuSharp/OsuApiClient.cs
+++ b/OsuSharp/OsuApiClient.cs
@@ -5,7 +5,6 @@ using OsuSharp.Models;
 using System.ComponentModel;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Reflection;
 using System.Web;
 
@@ -125,7 +124,7 @@ public partial class OsuApiClient
 
       // Append POST body if required
       if (method == HttpMethod.Post)
-        message.Content = JsonContent.Create(parameters);
+        message.Content = new StringContent(JsonConvert.SerializeObject(parameters, _jsonSettings), System.Text.Encoding.UTF8, "application/json");
 
       // Send the request and validate the response. If 404 is returned, return null.
       HttpResponseMessage response = await _http.SendAsync(message);

--- a/OsuSharp/OsuApiClient.cs
+++ b/OsuSharp/OsuApiClient.cs
@@ -124,7 +124,7 @@ public partial class OsuApiClient
 
       // Append POST body if required
       if (method == HttpMethod.Post)
-        message.Content = new StringContent(JsonConvert.SerializeObject(parameters, _jsonSettings), System.Text.Encoding.UTF8, "application/json");
+        message.Content = new StringContent(JsonConvert.SerializeObject(parameters, _jsonSettings), System.Text.Encoding.Default, "application/json");
 
       // Send the request and validate the response. If 404 is returned, return null.
       HttpResponseMessage response = await _http.SendAsync(message);

--- a/OsuSharp/OsuApiClient.cs
+++ b/OsuSharp/OsuApiClient.cs
@@ -176,9 +176,9 @@ public partial class OsuApiClient
       else if (kvp.Value is DateTime dt)
         // Use the ISO 8601 format for dates.
         str += dt.ToString("o");
-      else if (kvp.Value is bool boolean)
-        // The API is case-sensitive for booleans
-        str += boolean.ToString().ToLower();
+      else if (kvp.Value is bool b)
+        // Ensure all bools are passed in lower-case.
+        str += b.ToString().ToLower();
       else
         str += HttpUtility.HtmlEncode(kvp.Value!.ToString());
     }

--- a/OsuSharp/OsuApiClient.cs
+++ b/OsuSharp/OsuApiClient.cs
@@ -117,8 +117,11 @@ public partial class OsuApiClient
 
     try
     {
+      // Fallback to GET if nothing else is provided
+      method ??= HttpMethod.Get;
+
       // Prepare HTTP request
-      var message = new HttpRequestMessage(method ?? HttpMethod.Get, method == HttpMethod.Get ? $"{url}?{BuildQueryString(parameters)}" : url);
+      var message = new HttpRequestMessage(method, method == HttpMethod.Get ? $"{url}?{BuildQueryString(parameters)}" : url);
 
       // Append POST body if required
       if (method == HttpMethod.Post)

--- a/OsuSharp/OsuApiClient.cs
+++ b/OsuSharp/OsuApiClient.cs
@@ -5,6 +5,7 @@ using OsuSharp.Models;
 using System.ComponentModel;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Reflection;
 using System.Web;
 
@@ -116,8 +117,15 @@ public partial class OsuApiClient
 
     try
     {
+      // Prepare HTTP request
+      var message = new HttpRequestMessage(method ?? HttpMethod.Get, method == HttpMethod.Get ? $"{url}?{BuildQueryString(parameters)}" : url);
+
+      // Append POST body if required
+      if (method == HttpMethod.Post)
+        message.Content = JsonContent.Create(parameters);
+
       // Send the request and validate the response. If 404 is returned, return null.
-      HttpResponseMessage response = await _http.SendAsync(new HttpRequestMessage(method ?? HttpMethod.Get, $"{url}?{BuildQueryString(parameters)}"));
+      HttpResponseMessage response = await _http.SendAsync(message);
       if (response.StatusCode == HttpStatusCode.NotFound)
         return default;
 

--- a/OsuSharp/OsuApiClient.cs
+++ b/OsuSharp/OsuApiClient.cs
@@ -176,6 +176,9 @@ public partial class OsuApiClient
       else if (kvp.Value is DateTime dt)
         // Use the ISO 8601 format for dates.
         str += dt.ToString("o");
+      else if (kvp.Value is bool boolean)
+        // The API is case-sensitive for booleans
+        str += boolean.ToString().ToLower();
       else
         str += HttpUtility.HtmlEncode(kvp.Value!.ToString());
     }


### PR DESCRIPTION
As per [a discussion](https://github.com/minisbett/osu-sharp/pull/1#issuecomment-2303261158) in a previous PR.

Adds the ability to pass `mods` and `ruleset` to the `GetDifficultyAttributesAsync` method and the ability to send data in the body during a POST request.
